### PR TITLE
removing the need for global groc install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test: grapher.js
 	@grunt jasmine
 
 doc: grapher.js
-	@groc
+	@npm run doc
 
 grapher.js:
 	@npm run grapher.js

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Developing
 
 Grapher uses [Node.js](http://nodejs.org/). Install Node.js then run the following command:
 
-    sudo npm install
+    npm install
 
 This will install the development dependencies that Grapher uses to run its various tasks.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.1",
   "license": "Apache 2.0",
   "scripts": {
+    "doc": "groc",
     "grapher.js": "duo modules/grapher.js > build/grapher.js -s 'Grapher'",
     "grapher-min.js": "uglifyjs build/grapher.js -o build/grapher-min.js --preamble='\/\/ Ayasdi Inc. 2015\n\/\/ Grapher.js may be freely distributed under the Apache 2.0 license.\n'"
   },


### PR DESCRIPTION
It's not obvious we need to install groc separately and globally (npm install -g groc) just to run make and this should remove the need to do so.

For v1.1.0.